### PR TITLE
[Feature] : 코스 세부사항 조회

### DIFF
--- a/src/main/java/com/example/runway/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/runway/domain/auth/service/AuthService.java
@@ -1,20 +1,19 @@
 package com.example.runway.domain.auth.service;
 
 import com.example.runway.domain.auth.dto.LoginResponse;
-import com.example.runway.domain.user.User;
-import com.example.runway.domain.user.UserRepository;
+import com.example.runway.domain.user.entity.User;
+import com.example.runway.domain.user.repository.UserRepository;
+import com.example.runway.domain.user.entity.UserStatus;
 import com.example.runway.global.jwt.JwtProvider;
 import com.example.runway.infra.kakao.KakaoOAuthClient;
 import com.example.runway.infra.kakao.dto.KakaoTokenResponseDto;
 import com.example.runway.infra.kakao.dto.KakaoUserInfoResponseDto;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
@@ -57,7 +56,7 @@ public class AuthService {
                                 .email(email)
                                 .nickname(nickname)
                                 .profileImageUrl(profileImageUrl)
-                                .status(com.example.runway.domain.user.UserStatus.ACTIVE)
+                                .status(UserStatus.ACTIVE)
                                 .build()
                 );
 

--- a/src/main/java/com/example/runway/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/runway/domain/course/controller/CourseController.java
@@ -1,0 +1,19 @@
+package com.example.runway.domain.course.controller;
+
+import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("public/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @GetMapping("/{crsIdx}")
+    public CourseDto getCourse(@PathVariable String crsIdx) {
+        return courseService.getById(crsIdx);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
@@ -1,0 +1,54 @@
+package com.example.runway.domain.course.dto;
+
+import com.example.runway.domain.course.entity.Course;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CourseDto(
+        String crsIdx,
+        String routeIdx,
+        String crsKorNm,
+        Integer crsDstnc,
+        Integer crsTotlRqrmHour,
+        Byte crsLevel,
+        String crsCycle,
+
+        String crsContents,
+        String crsSummary,
+        String crsTourInfo,
+        String travelerinfo,
+
+        String sigun,
+        Course.BrdDiv brdDiv,
+        String gpxFilePath,
+        String crsImg,
+
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static CourseDto from(Course c) {
+        return new CourseDto(
+                c.getCrsIdx(),
+                c.getRouteIdx(),
+                c.getCrsKorNm(),
+                c.getCrsDstnc(),
+                c.getCrsTotlRqrmHour(),
+                c.getCrsLevel(),
+                c.getCrsCycle(),
+
+                c.getCrsContents(),
+                c.getCrsSummary(),
+                c.getCrsTourInfo(),
+                c.getTravelerinfo(),
+
+                c.getSigun(),
+                c.getBrdDiv(),
+                c.getGpxFilePath(),
+                c.getCrsImg(),
+
+                c.getCreated_at(),
+                c.getUpdated_at()
+        );
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
@@ -1,5 +1,6 @@
 package com.example.runway.domain.course.dto;
 
+import com.example.runway.domain.course.entity.BrdDiv;
 import com.example.runway.domain.course.entity.Course;
 
 import java.math.BigDecimal;
@@ -11,7 +12,7 @@ public record CourseDto(
         String crsKorNm,
         Integer crsDstnc,
         Integer crsTotlRqrmHour,
-        Byte crsLevel,
+        Integer crsLevel,
         String crsCycle,
 
         String crsContents,
@@ -20,7 +21,7 @@ public record CourseDto(
         String travelerinfo,
 
         String sigun,
-        Course.BrdDiv brdDiv,
+        BrdDiv brdDiv,
         String gpxFilePath,
         String crsImg,
 
@@ -30,7 +31,7 @@ public record CourseDto(
     public static CourseDto from(Course c) {
         return new CourseDto(
                 c.getCrsIdx(),
-                c.getRouteIdx(),
+                c.getRoute().getRouteIdx(),
                 c.getCrsKorNm(),
                 c.getCrsDstnc(),
                 c.getCrsTotlRqrmHour(),
@@ -40,15 +41,15 @@ public record CourseDto(
                 c.getCrsContents(),
                 c.getCrsSummary(),
                 c.getCrsTourInfo(),
-                c.getTravelerinfo(),
+                c.getTravelerInfo(),
 
                 c.getSigun(),
                 c.getBrdDiv(),
-                c.getGpxFilePath(),
-                c.getCrsImg(),
+                c.getGpxPath(),
+                c.getCrsImgUrl(),
 
-                c.getCreated_at(),
-                c.getUpdated_at()
+                c.getCreatedTime(),
+                c.getModifiedTime()
         );
     }
 }

--- a/src/main/java/com/example/runway/domain/course/entity/Course.java
+++ b/src/main/java/com/example/runway/domain/course/entity/Course.java
@@ -4,7 +4,6 @@ import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "courses")
-public class Course extends BaseEntity {
+public class Course {
     @Id
     @Column(name = "crs_idx", nullable = false, unique = true)
     private String crsIdx;
@@ -25,7 +24,7 @@ public class Course extends BaseEntity {
     private int crsDstnc;
 
     @Column(name = "crs_totl_rqrm_hour", nullable = false)
-    private int crsTotlRrrmHour;
+    private int crsTotlRqrmHour;
 
     @Column(name = "crs_level", nullable = false, columnDefinition = "TINYINT")
     private int crsLevel;
@@ -63,4 +62,8 @@ public class Course extends BaseEntity {
 
     @Column(name = "modified_time", nullable = true)
     private LocalDateTime modifiedTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_idx") // Route 엔티티의 기본키(route_idx)를 외래키로 연결
+    private Route route;
 }

--- a/src/main/java/com/example/runway/domain/course/entity/Route.java
+++ b/src/main/java/com/example/runway/domain/course/entity/Route.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "routes")
-public class Route extends BaseEntity {
+public class Route {
     @Id
     @Column(name = "route_idx", nullable = false, unique = true)
     private String routeIdx;
@@ -35,4 +36,7 @@ public class Route extends BaseEntity {
 
     @Column(name = "modified_time", nullable = true)
     private LocalDateTime modifiedTime;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL) // Course 엔티티의 'route' 필드에 매핑
+    private List<Course> courses;
 }

--- a/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
+++ b/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.runway.domain.course.error;
+
+import com.example.runway.global.dto.ErrorReason;
+import com.example.runway.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+
+@Getter
+@AllArgsConstructor
+public enum CourseErrorCode implements BaseErrorCode {
+
+    CourseNotFound(INTERNAL_SERVER_ERROR,"Course_500_1","코스를 찾지 못하였습니다.");
+
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.of(status.value(), code, reason);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/error/CourseFailed.java
+++ b/src/main/java/com/example/runway/domain/course/error/CourseFailed.java
@@ -1,0 +1,13 @@
+package com.example.runway.domain.course.error;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class CourseFailed extends BaseErrorException {
+
+    public static final CourseFailed Exception = new CourseFailed();
+
+
+    public CourseFailed() {
+        super(CourseErrorCode.CourseNotFound);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
@@ -1,0 +1,8 @@
+package com.example.runway.domain.course.repository;
+
+import com.example.runway.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface CourseRepository extends JpaRepository<Course, String>, JpaSpecificationExecutor<Course> {
+}

--- a/src/main/java/com/example/runway/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/runway/domain/course/service/CourseService.java
@@ -1,0 +1,23 @@
+package com.example.runway.domain.course.service;
+
+import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.course.error.CourseFailed;
+import com.example.runway.domain.course.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    public CourseDto getById(String crsIdx) {
+        Course c = courseRepository.findById(crsIdx)
+                .orElseThrow(() -> CourseFailed.Exception);
+        return CourseDto.from(c);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/runway/domain/favorite/controller/FavoriteController.java
@@ -1,0 +1,23 @@
+package com.example.runway.domain.favorite.controller;
+
+
+import com.example.runway.domain.favorite.service.FavoriteService;
+import com.example.runway.global.jwt.annotation.LoginUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/courses")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @PostMapping("/{crsIdx}/favorite")
+    public void favorite(@LoginUserId Long userId,
+                         @PathVariable("crsIdx") String crsIdx) {
+
+        favoriteService.addFavorite(userId, crsIdx);
+    }
+
+}

--- a/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
@@ -1,7 +1,7 @@
 package com.example.runway.domain.favorite.entity;
 
 import com.example.runway.domain.course.entity.Course;
-import com.example.runway.domain.user.User;
+import com.example.runway.domain.user.entity.User;
 import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
@@ -1,0 +1,39 @@
+package com.example.runway.domain.favorite.entity;
+
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.user.User;
+import com.example.runway.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Table(
+        name = "user_course_favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_user_course",
+                columnNames = {"user_id", "crs_idx"}
+        )
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;  // 단일 PK
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_fav_user"))
+    private User user;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "crs_idx", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_fav_course"))
+    private Course course;
+}

--- a/src/main/java/com/example/runway/domain/favorite/error/FavoriteErrorCode.java
+++ b/src/main/java/com/example/runway/domain/favorite/error/FavoriteErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.runway.domain.favorite.error;
+
+import com.example.runway.global.dto.ErrorReason;
+import com.example.runway.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteErrorCode implements BaseErrorCode {
+
+    FavoriteDuplicate(CONFLICT,"Favorite_409_1","이미 찜한 코스입니다.");
+
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.of(status.value(), code, reason);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/error/FavoriteFailed.java
+++ b/src/main/java/com/example/runway/domain/favorite/error/FavoriteFailed.java
@@ -1,0 +1,13 @@
+package com.example.runway.domain.favorite.error;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class FavoriteFailed extends BaseErrorException {
+
+    public static final FavoriteFailed Exception = new FavoriteFailed();
+
+
+    public FavoriteFailed() {
+        super(FavoriteErrorCode.FavoriteDuplicate);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/runway/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,8 @@
+package com.example.runway.domain.favorite.repository;
+
+import com.example.runway.domain.favorite.entity.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    boolean existsByUser_IdAndCourse_CrsIdx(Long userId, String crsIdx);
+}

--- a/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
@@ -1,14 +1,13 @@
 package com.example.runway.domain.favorite.service;
 
-import com.amazonaws.util.FakeIOException;
 import com.example.runway.domain.course.entity.Course;
 import com.example.runway.domain.course.error.CourseFailed;
 import com.example.runway.domain.course.repository.CourseRepository;
 import com.example.runway.domain.favorite.entity.Favorite;
 import com.example.runway.domain.favorite.error.FavoriteFailed;
 import com.example.runway.domain.favorite.repository.FavoriteRepository;
-import com.example.runway.domain.user.User;
-import com.example.runway.domain.user.UserRepository;
+import com.example.runway.domain.user.entity.User;
+import com.example.runway.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,44 @@
+package com.example.runway.domain.favorite.service;
+
+import com.amazonaws.util.FakeIOException;
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.course.error.CourseFailed;
+import com.example.runway.domain.course.repository.CourseRepository;
+import com.example.runway.domain.favorite.entity.Favorite;
+import com.example.runway.domain.favorite.error.FavoriteFailed;
+import com.example.runway.domain.favorite.repository.FavoriteRepository;
+import com.example.runway.domain.user.User;
+import com.example.runway.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    public void addFavorite(Long userId, String crsIdx) {
+        // 이미 찜한 경우에는 예외 던짐
+        if (favoriteRepository.existsByUser_IdAndCourse_CrsIdx(userId, crsIdx)) {
+            throw FavoriteFailed.Exception;
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+        Course course = courseRepository.findById(crsIdx)
+                .orElseThrow(() -> CourseFailed.Exception);
+
+        Favorite fav = Favorite.builder()
+                .user(user)
+                .course(course)
+                .build();
+
+        favoriteRepository.save(fav);
+    }
+}

--- a/src/main/java/com/example/runway/domain/user/entity/User.java
+++ b/src/main/java/com/example/runway/domain/user/entity/User.java
@@ -1,12 +1,8 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.entity;
 
 import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(

--- a/src/main/java/com/example/runway/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/example/runway/domain/user/entity/UserStatus.java
@@ -1,4 +1,4 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.entity;
 
 public enum UserStatus {
     ACTIVE, SUSPENDED, DELETED

--- a/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.repository;
 
+import com.example.runway.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/example/runway/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/runway/global/config/SecurityConfig.java
@@ -42,8 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health")
                         .permitAll()
                         .anyRequest().authenticated())
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .formLogin(AbstractHttpConfigurer::disable);
 
         //JWT 필터 추가
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/runway/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/runway/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.runway.global.config;
 
+import com.example.runway.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,10 +10,16 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -27,7 +35,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/signup", "/", "/login", "/Oauth2/**","/auth/**")
+                        .requestMatchers("/signup", "/", "/login", "/Oauth2/**","/auth/**","public/**")
                         .permitAll()
                         .requestMatchers(SwaggerPatterns)
                         .permitAll()
@@ -36,6 +44,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
+
+        //JWT 필터 추가
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/com/example/runway/global/config/WebConfig.java
+++ b/src/main/java/com/example/runway/global/config/WebConfig.java
@@ -1,14 +1,28 @@
 package com.example.runway.global.config;
 
+import com.example.runway.global.jwt.argument_resolver.LoginUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     @Value("${server.url}")
     private String SERVER_URL;
+
+    private final LoginUserIdArgumentResolver loginUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserIdArgumentResolver);
+    }
+
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/example/runway/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.example.runway.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        // 이미 인증되어 있으면 패스
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = resolveToken(request);
+
+            if (token != null) {
+                try {
+                    if (jwtProvider.validate(token)) {
+                        String subject = jwtProvider.getSubject(token); // 로그인 시 subject = userId 로 발급했어야 함
+                        Long userId = Long.parseLong(subject);
+
+                        var principal = new JwtUserPrincipal(userId);
+                        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER")); // 필요시 롤 클레임에서 채우기
+
+                        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+                        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                    }
+                } catch (Exception e) {
+                    // 토큰이 있지만 유효하지 않으면 바로 401 리턴(원하면 주석 처리하고 체인 계속 타도 됨)
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"status\":401,\"error\":\"Unauthorized\",\"message\":\"Invalid or expired token\"}");
+                    return;
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest req) {
+        String auth = req.getHeader("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            return auth.substring(7);
+        }
+        // 쿠키 사용 시(선택)
+        if (req.getCookies() != null) {
+            for (Cookie c : req.getCookies()) {
+                if ("ACCESS_TOKEN".equals(c.getName())) {
+                    return c.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/runway/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtProvider.java
@@ -27,8 +27,8 @@ public class JwtProvider {
     public String createAccessToken(String subject, Map<String, Object> claims) {
         Instant now = Instant.now();
         return Jwts.builder()
-                .setSubject(subject)
                 .setClaims(claims)
+                .setSubject(subject)
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(now.plusSeconds(accessExpSeconds)))
                 .signWith(signingKey, SignatureAlgorithm.HS256)

--- a/src/main/java/com/example/runway/global/jwt/JwtUserPrincipal.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtUserPrincipal.java
@@ -1,0 +1,3 @@
+package com.example.runway.global.jwt;
+
+public record JwtUserPrincipal(Long userId) {}

--- a/src/main/java/com/example/runway/global/jwt/annotation/LoginUserId.java
+++ b/src/main/java/com/example/runway/global/jwt/annotation/LoginUserId.java
@@ -1,0 +1,12 @@
+package com.example.runway.global.jwt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+    boolean required() default true;
+}

--- a/src/main/java/com/example/runway/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/example/runway/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.example.runway.global.jwt.argument_resolver;
+
+import com.example.runway.global.jwt.JwtUserPrincipal;
+import com.example.runway.global.jwt.annotation.LoginUserId; // ← 오타 주의: annotation X
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class)
+                && (parameter.getParameterType() == Long.class || parameter.getParameterType() == long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mav,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        LoginUserId ann = parameter.getParameterAnnotation(LoginUserId.class);
+        boolean required = (ann == null) || ann.required();
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || auth instanceof AnonymousAuthenticationToken || !auth.isAuthenticated()) {
+            if (required) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+            return null;
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof JwtUserPrincipal p) {
+            return p.userId();
+        }
+
+        // 예상과 다른 Principal 타입이면 인증 실패 처리
+        if (required) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보를 확인할 수 없습니다.");
+        return null;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,5 +4,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  jpa:
+    hibernate:
+      ddl-auto: update   # create, create-drop, update, validate, none 중 하나
+    properties:
+      hibernate:
+        format_sql: true
+
 server:
   url: ${SERVER_LOCAL_URL}


### PR DESCRIPTION
## 📄 개요

- 코스 세부정보 조회 API와 코스 찜하기 기능을 추가했습니다.
- 사용자가 특정 코스의 상세 정보를 확인할 수 있고, 로그인된 상태에서 해당 코스를 찜/저장할 수 있습니다.

---

## ✅ 변경 사항
- [x] 기능 추가
- 코스 세부사항 조회 API 구현 (GET /courses/{crsIdx})
- 코스 찜하기 기능 구현 (POST /courses/{crsIdx}/favorite)


---

## 🧪 테스트 방법

회원가입/로그인 후 JWT 발급

코스 세부정보 조회 테스트

GET /courses/{crsIdx} 호출 → 해당 코스의 거리, 소요시간, 난이도, 설명 등 상세 정보 반환 확인

코스 찜하기 테스트

POST /courses/{crsIdx}/favorite 호출 (헤더에 Authorization: Bearer <토큰> 포함)

찜 추가 성공 시 DB에 해당 유저-코스 매핑 레코드가 생성되는지 확인

---

## 📸 스크린샷 (UI 변경 시 필수)

### 코스 상세조회

<img width="1024" height="655" alt="image" src="https://github.com/user-attachments/assets/c68b1289-89e6-4474-ad55-b60d82abb4d5" />

### 찜추가(실패 : 이미 설정된 찜)

<img width="1024" height="564" alt="image" src="https://github.com/user-attachments/assets/c266f19a-a45d-417b-9851-8633e2c55362" />

### 찜추가 성공

<img width="1027" height="515" alt="image" src="https://github.com/user-attachments/assets/6f55c556-2cbd-4d08-acd5-ca52274d14f7" />



---

## 🔗 관련 이슈

#3 

---

## ⚠️ 참고 사항
- 리뷰어가 알아야 할 추가 설명이나 주의 사항이 있다면 작성해주세요.
