### PR TITLE
[Feature] 인기 코스 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
 	// actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//위도,경도 변환
+	implementation 'org.locationtech.proj4j:proj4j:1.2.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/runway/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/runway/domain/auth/service/AuthService.java
@@ -1,20 +1,19 @@
 package com.example.runway.domain.auth.service;
 
 import com.example.runway.domain.auth.dto.LoginResponse;
-import com.example.runway.domain.user.User;
-import com.example.runway.domain.user.UserRepository;
+import com.example.runway.domain.user.entity.User;
+import com.example.runway.domain.user.repository.UserRepository;
+import com.example.runway.domain.user.entity.UserStatus;
 import com.example.runway.global.jwt.JwtProvider;
 import com.example.runway.infra.kakao.KakaoOAuthClient;
 import com.example.runway.infra.kakao.dto.KakaoTokenResponseDto;
 import com.example.runway.infra.kakao.dto.KakaoUserInfoResponseDto;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
@@ -57,7 +56,7 @@ public class AuthService {
                                 .email(email)
                                 .nickname(nickname)
                                 .profileImageUrl(profileImageUrl)
-                                .status(com.example.runway.domain.user.UserStatus.ACTIVE)
+                                .status(UserStatus.ACTIVE)
                                 .build()
                 );
 

--- a/src/main/java/com/example/runway/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/runway/domain/course/controller/CourseController.java
@@ -1,19 +1,38 @@
 package com.example.runway.domain.course.controller;
 
 import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.dto.RecentCourseDto;
 import com.example.runway.domain.course.service.CourseService;
+import com.example.runway.global.jwt.annotation.LoginUserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("public/courses")
 @RequiredArgsConstructor
 public class CourseController {
 
     private final CourseService courseService;
 
-    @GetMapping("/{crsIdx}")
+    // 코스 상세 조회 (로그인 필요 x)
+    @GetMapping("/public/courses/{crsIdx}")
     public CourseDto getCourse(@PathVariable String crsIdx) {
         return courseService.getById(crsIdx);
+    }
+
+    // 코스 조회 기록을 남기는 API
+    @PostMapping("/courses/{crsIdx}/history")
+    public ResponseEntity<Void> updateLastViewedCourse(@LoginUserId Long userId, @PathVariable String crsIdx) {
+        courseService.updateLastViewedCourse(userId, crsIdx);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    // 최근 본 코스 1개를 조회하는 API
+    @GetMapping("/courses/history")
+    public ResponseEntity<RecentCourseDto> getLastViewedCourse(@LoginUserId Long userId) {
+        return courseService.getLastViewedCourse(userId)
+                .map(ResponseEntity::ok) // 조회된 코스가 있으면 200 OK와 함께 DTO 반환
+                .orElseGet(() -> ResponseEntity.noContent().build()); // 조회된 코스가 없으면 204 No Content 반환
     }
 }

--- a/src/main/java/com/example/runway/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/runway/domain/course/controller/CourseController.java
@@ -1,0 +1,19 @@
+package com.example.runway.domain.course.controller;
+
+import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("public/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @GetMapping("/{crsIdx}")
+    public CourseDto getCourse(@PathVariable String crsIdx) {
+        return courseService.getById(crsIdx);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/runway/domain/course/controller/CourseController.java
@@ -1,6 +1,7 @@
 package com.example.runway.domain.course.controller;
 
 import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.dto.PopularCourseDto;
 import com.example.runway.domain.course.dto.RecentCourseDto;
 import com.example.runway.domain.course.service.CourseService;
 import com.example.runway.global.jwt.annotation.LoginUserId;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +37,12 @@ public class CourseController {
         return courseService.getLastViewedCourse(userId)
                 .map(ResponseEntity::ok) // 조회된 코스가 있으면 200 OK와 함께 DTO 반환
                 .orElseGet(() -> ResponseEntity.noContent().build()); // 조회된 코스가 없으면 204 No Content 반환
+    }
+
+    // 인기 코스 조회(전국 단위, 로그인 안해도 됨)
+    @GetMapping("/public/courses/popular")
+    public ResponseEntity<List<PopularCourseDto>> getPopularCourses() {
+        List<PopularCourseDto> result = courseService.getPopularCourses(10);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
@@ -1,0 +1,54 @@
+package com.example.runway.domain.course.dto;
+
+import com.example.runway.domain.course.entity.Course;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CourseDto(
+        String crsIdx,
+        String routeIdx,
+        String crsKorNm,
+        Integer crsDstnc,
+        Integer crsTotlRqrmHour,
+        Byte crsLevel,
+        String crsCycle,
+
+        String crsContents,
+        String crsSummary,
+        String crsTourInfo,
+        String travelerinfo,
+
+        String sigun,
+        Course.BrdDiv brdDiv,
+        String gpxFilePath,
+        String crsImg,
+
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static CourseDto from(Course c) {
+        return new CourseDto(
+                c.getCrsIdx(),
+                c.getRouteIdx(),
+                c.getCrsKorNm(),
+                c.getCrsDstnc(),
+                c.getCrsTotlRqrmHour(),
+                c.getCrsLevel(),
+                c.getCrsCycle(),
+
+                c.getCrsContents(),
+                c.getCrsSummary(),
+                c.getCrsTourInfo(),
+                c.getTravelerinfo(),
+
+                c.getSigun(),
+                c.getBrdDiv(),
+                c.getGpxFilePath(),
+                c.getCrsImg(),
+
+                c.getCreated_at(),
+                c.getUpdated_at()
+        );
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/CourseDto.java
@@ -1,5 +1,6 @@
 package com.example.runway.domain.course.dto;
 
+import com.example.runway.domain.course.entity.BrdDiv;
 import com.example.runway.domain.course.entity.Course;
 
 import java.math.BigDecimal;
@@ -11,7 +12,7 @@ public record CourseDto(
         String crsKorNm,
         Integer crsDstnc,
         Integer crsTotlRqrmHour,
-        Byte crsLevel,
+        Integer crsLevel,
         String crsCycle,
 
         String crsContents,
@@ -20,7 +21,7 @@ public record CourseDto(
         String travelerinfo,
 
         String sigun,
-        Course.BrdDiv brdDiv,
+        BrdDiv brdDiv,
         String gpxFilePath,
         String crsImg,
 
@@ -30,7 +31,7 @@ public record CourseDto(
     public static CourseDto from(Course c) {
         return new CourseDto(
                 c.getCrsIdx(),
-                c.getRouteIdx(),
+                c.getRoute().getRouteIdx(),
                 c.getCrsKorNm(),
                 c.getCrsDstnc(),
                 c.getCrsTotlRqrmHour(),
@@ -40,15 +41,15 @@ public record CourseDto(
                 c.getCrsContents(),
                 c.getCrsSummary(),
                 c.getCrsTourInfo(),
-                c.getTravelerinfo(),
+                c.getTravelerInfo(),
 
                 c.getSigun(),
                 c.getBrdDiv(),
-                c.getGpxFilePath(),
-                c.getCrsImg(),
+                c.getGpxPath(),
+                c.getCrsImgUrl(),
 
-                c.getCreated_at(),
-                c.getUpdated_at()
+                c.getCreatedTime(),
+                c.getModifiedTime()
         );
     }
 }

--- a/src/main/java/com/example/runway/domain/course/dto/PopularCourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/PopularCourseDto.java
@@ -1,0 +1,19 @@
+package com.example.runway.domain.course.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인기 코스 정보 응답 DTO")
+public record PopularCourseDto(
+        @Schema(description = "시/군 이름")
+        String sigun,
+
+        @Schema(description = "코스 한글 이름")
+        String crsKorNm,
+
+        @Schema(description = "코스 idx")
+        String crsIdx,
+
+        @Schema(description = "코스 썸네일 이미지 URL")
+        String crsImgUrl
+) {
+}

--- a/src/main/java/com/example/runway/domain/course/dto/RecentCourseDto.java
+++ b/src/main/java/com/example/runway/domain/course/dto/RecentCourseDto.java
@@ -1,0 +1,22 @@
+package com.example.runway.domain.course.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "최근 본 코스 정보 DTO")
+public record RecentCourseDto(
+        @Schema(description = "코스 ID")
+        String crsIdx,
+
+        @Schema(description = "코스 한글 이름")
+        String crsKorNm,
+
+        @Schema(description = "코스 거리")
+        int crsDstnc,
+
+        @Schema(description = "마지막으로 조회한 시간")
+        String viewedAt
+
+) {
+
+}

--- a/src/main/java/com/example/runway/domain/course/entity/Course.java
+++ b/src/main/java/com/example/runway/domain/course/entity/Course.java
@@ -4,7 +4,6 @@ import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "courses")
-public class Course extends BaseEntity {
+public class Course {
     @Id
     @Column(name = "crs_idx", nullable = false, unique = true)
     private String crsIdx;
@@ -25,7 +24,7 @@ public class Course extends BaseEntity {
     private int crsDstnc;
 
     @Column(name = "crs_totl_rqrm_hour", nullable = false)
-    private int crsTotlRrrmHour;
+    private int crsTotlRqrmHour;
 
     @Column(name = "crs_level", nullable = false, columnDefinition = "TINYINT")
     private int crsLevel;
@@ -63,4 +62,8 @@ public class Course extends BaseEntity {
 
     @Column(name = "modified_time", nullable = true)
     private LocalDateTime modifiedTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_idx") // Route 엔티티의 기본키(route_idx)를 외래키로 연결
+    private Route route;
 }

--- a/src/main/java/com/example/runway/domain/course/entity/Route.java
+++ b/src/main/java/com/example/runway/domain/course/entity/Route.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "routes")
-public class Route extends BaseEntity {
+public class Route {
     @Id
     @Column(name = "route_idx", nullable = false, unique = true)
     private String routeIdx;
@@ -35,4 +36,7 @@ public class Route extends BaseEntity {
 
     @Column(name = "modified_time", nullable = true)
     private LocalDateTime modifiedTime;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL) // Course 엔티티의 'route' 필드에 매핑
+    private List<Course> courses;
 }

--- a/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
+++ b/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.runway.domain.course.error;
+
+import com.example.runway.global.dto.ErrorReason;
+import com.example.runway.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+
+@Getter
+@AllArgsConstructor
+public enum CourseErrorCode implements BaseErrorCode {
+
+    CourseNotFound(INTERNAL_SERVER_ERROR,"Course_500_1","코스를 찾지 못하였습니다.");
+
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.of(status.value(), code, reason);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
+++ b/src/main/java/com/example/runway/domain/course/error/CourseErrorCode.java
@@ -14,7 +14,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @AllArgsConstructor
 public enum CourseErrorCode implements BaseErrorCode {
 
-    CourseNotFound(NOT_FOUND, "Course_404_1", "코스를 찾지 못하였습니다.");
+    CourseNotFound(NOT_FOUND, "Course_404_1", "코스를 찾지 못하였습니다."),
+    PopularCourseNotFound(NOT_FOUND, "Course_404_2", "인기 코스 데이터가 충분하지 않습니다.");
+
 
 
     private HttpStatus status;

--- a/src/main/java/com/example/runway/domain/course/error/CourseFailed.java
+++ b/src/main/java/com/example/runway/domain/course/error/CourseFailed.java
@@ -1,0 +1,13 @@
+package com.example.runway.domain.course.error;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class CourseFailed extends BaseErrorException {
+
+    public static final CourseFailed Exception = new CourseFailed();
+
+
+    public CourseFailed() {
+        super(CourseErrorCode.CourseNotFound);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/error/PopularCourseNotFound.java
+++ b/src/main/java/com/example/runway/domain/course/error/PopularCourseNotFound.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.course.error;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class PopularCourseNotFound extends BaseErrorException {
+    public static final PopularCourseNotFound Exception = new PopularCourseNotFound();
+
+    public PopularCourseNotFound() {
+        super(CourseErrorCode.PopularCourseNotFound);
+    }
+}

--- a/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
@@ -1,8 +1,14 @@
 package com.example.runway.domain.course.repository;
 
 import com.example.runway.domain.course.entity.Course;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CourseRepository extends JpaRepository<Course, String>, JpaSpecificationExecutor<Course> {
+    @Query("SELECT f.course FROM Favorite f GROUP BY f.course ORDER BY COUNT(f.course) DESC")
+    List<Course> findPopularCourses(Pageable pageable);
 }

--- a/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/runway/domain/course/repository/CourseRepository.java
@@ -1,0 +1,8 @@
+package com.example.runway.domain.course.repository;
+
+import com.example.runway.domain.course.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface CourseRepository extends JpaRepository<Course, String>, JpaSpecificationExecutor<Course> {
+}

--- a/src/main/java/com/example/runway/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/runway/domain/course/service/CourseService.java
@@ -1,14 +1,17 @@
 package com.example.runway.domain.course.service;
 
 import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.dto.PopularCourseDto;
 import com.example.runway.domain.course.dto.RecentCourseDto;
 import com.example.runway.domain.course.entity.Course;
 import com.example.runway.domain.course.error.CourseFailed;
+import com.example.runway.domain.course.error.PopularCourseNotFound;
 import com.example.runway.domain.course.repository.CourseRepository;
 import com.example.runway.domain.user.entity.User;
 import com.example.runway.domain.user.exception.UserFailed;
 import com.example.runway.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +19,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -76,5 +81,28 @@ public class CourseService {
                 lastViewedCourse.getCrsDstnc(),
                 formattedDate
         ));
+    }
+
+    /**
+     * 인기 코스 목록을 조회하는 메소드 (찜 많은 순)
+     */
+    @Transactional(readOnly = true)
+    public List<PopularCourseDto> getPopularCourses(int size) {
+        PageRequest pageRequest = PageRequest.of(0, size);
+        List<Course> popularCourses = courseRepository.findPopularCourses(pageRequest);
+
+        if (popularCourses.isEmpty()) {
+            throw PopularCourseNotFound.Exception;
+        }
+
+        // Course 엔티티를 PopularCourseDto 레코드로 변환합니다.
+        return popularCourses.stream()
+                .map(course -> new PopularCourseDto(
+                        course.getSigun(),
+                        course.getCrsKorNm(),
+                        course.getCrsIdx(),
+                        course.getCrsImgUrl()
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/runway/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/runway/domain/course/service/CourseService.java
@@ -1,23 +1,80 @@
 package com.example.runway.domain.course.service;
 
 import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.dto.RecentCourseDto;
 import com.example.runway.domain.course.entity.Course;
 import com.example.runway.domain.course.error.CourseFailed;
 import com.example.runway.domain.course.repository.CourseRepository;
+import com.example.runway.domain.user.entity.User;
+import com.example.runway.domain.user.exception.UserFailed;
+import com.example.runway.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class CourseService {
 
     private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
 
     public CourseDto getById(String crsIdx) {
         Course c = courseRepository.findById(crsIdx)
                 .orElseThrow(() -> CourseFailed.Exception);
         return CourseDto.from(c);
+    }
+
+    /**
+     * 사용자의 마지막 코스 조회 기록을 업데이트하는 메소드
+     */
+    @Transactional
+    public void updateLastViewedCourse(Long userId, String crsIdx) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserFailed.Exception);
+        Course course = courseRepository.findById(crsIdx)
+                .orElseThrow(() -> CourseFailed.Exception);
+
+        // User 엔티티의 편의 메소드를 사용하여 마지막으로 본 코스를 업데이트
+        user.updateLastViewedCourse(course);
+    }
+
+
+    /**
+     * 사용자가 마지막으로 본 코스 정보를 조회하는 메소드
+     */
+    @Transactional(readOnly = true)
+    public Optional<RecentCourseDto> getLastViewedCourse(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserFailed.Exception);
+
+        // User 객체에서 마지막으로 본 코스(Course)와 시간(LocalDateTime)을 가져옵니다.
+        Course lastViewedCourse = user.getLastViewedCourse();
+        LocalDateTime lastViewedAt = user.getLastViewedAt();
+
+        // 조회 기록이 없으면 (코스가 null이면) 빈 Optional을 반환합니다.
+        if (lastViewedCourse == null) {
+            return Optional.empty();
+        }
+        // 날짜 형식을 정의
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        // LocalDateTime 객체를 정의된 형식의 문자열로 변환
+        String formattedDate = lastViewedAt.format(formatter);
+
+        // 코스 정보와 조회 시간으로 RecentCourseDto를 생성하여 반환합니다.
+        return Optional.of(new RecentCourseDto(
+                lastViewedCourse.getCrsIdx(),
+                lastViewedCourse.getCrsKorNm(),
+                lastViewedCourse.getCrsDstnc(),
+                formattedDate
+        ));
     }
 }

--- a/src/main/java/com/example/runway/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/runway/domain/course/service/CourseService.java
@@ -1,0 +1,23 @@
+package com.example.runway.domain.course.service;
+
+import com.example.runway.domain.course.dto.CourseDto;
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.course.error.CourseFailed;
+import com.example.runway.domain.course.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+
+    public CourseDto getById(String crsIdx) {
+        Course c = courseRepository.findById(crsIdx)
+                .orElseThrow(() -> CourseFailed.Exception);
+        return CourseDto.from(c);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/runway/domain/favorite/controller/FavoriteController.java
@@ -1,0 +1,23 @@
+package com.example.runway.domain.favorite.controller;
+
+
+import com.example.runway.domain.favorite.service.FavoriteService;
+import com.example.runway.global.jwt.annotation.LoginUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/courses")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @PostMapping("/{crsIdx}/favorite")
+    public void favorite(@LoginUserId Long userId,
+                         @PathVariable("crsIdx") String crsIdx) {
+
+        favoriteService.addFavorite(userId, crsIdx);
+    }
+
+}

--- a/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
@@ -1,7 +1,7 @@
 package com.example.runway.domain.favorite.entity;
 
 import com.example.runway.domain.course.entity.Course;
-import com.example.runway.domain.user.User;
+import com.example.runway.domain.user.entity.User;
 import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/runway/domain/favorite/entity/Favorite.java
@@ -1,0 +1,39 @@
+package com.example.runway.domain.favorite.entity;
+
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.user.User;
+import com.example.runway.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Table(
+        name = "user_course_favorite",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_user_course",
+                columnNames = {"user_id", "crs_idx"}
+        )
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;  // 단일 PK
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_fav_user"))
+    private User user;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "crs_idx", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_fav_course"))
+    private Course course;
+}

--- a/src/main/java/com/example/runway/domain/favorite/error/FavoriteErrorCode.java
+++ b/src/main/java/com/example/runway/domain/favorite/error/FavoriteErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.runway.domain.favorite.error;
+
+import com.example.runway.global.dto.ErrorReason;
+import com.example.runway.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteErrorCode implements BaseErrorCode {
+
+    FavoriteDuplicate(CONFLICT,"Favorite_409_1","이미 찜한 코스입니다.");
+
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.of(status.value(), code, reason);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/error/FavoriteFailed.java
+++ b/src/main/java/com/example/runway/domain/favorite/error/FavoriteFailed.java
@@ -1,0 +1,13 @@
+package com.example.runway.domain.favorite.error;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class FavoriteFailed extends BaseErrorException {
+
+    public static final FavoriteFailed Exception = new FavoriteFailed();
+
+
+    public FavoriteFailed() {
+        super(FavoriteErrorCode.FavoriteDuplicate);
+    }
+}

--- a/src/main/java/com/example/runway/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/runway/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,8 @@
+package com.example.runway.domain.favorite.repository;
+
+import com.example.runway.domain.favorite.entity.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    boolean existsByUser_IdAndCourse_CrsIdx(Long userId, String crsIdx);
+}

--- a/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
@@ -1,14 +1,13 @@
 package com.example.runway.domain.favorite.service;
 
-import com.amazonaws.util.FakeIOException;
 import com.example.runway.domain.course.entity.Course;
 import com.example.runway.domain.course.error.CourseFailed;
 import com.example.runway.domain.course.repository.CourseRepository;
 import com.example.runway.domain.favorite.entity.Favorite;
 import com.example.runway.domain.favorite.error.FavoriteFailed;
 import com.example.runway.domain.favorite.repository.FavoriteRepository;
-import com.example.runway.domain.user.User;
-import com.example.runway.domain.user.UserRepository;
+import com.example.runway.domain.user.entity.User;
+import com.example.runway.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/runway/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,44 @@
+package com.example.runway.domain.favorite.service;
+
+import com.amazonaws.util.FakeIOException;
+import com.example.runway.domain.course.entity.Course;
+import com.example.runway.domain.course.error.CourseFailed;
+import com.example.runway.domain.course.repository.CourseRepository;
+import com.example.runway.domain.favorite.entity.Favorite;
+import com.example.runway.domain.favorite.error.FavoriteFailed;
+import com.example.runway.domain.favorite.repository.FavoriteRepository;
+import com.example.runway.domain.user.User;
+import com.example.runway.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    public void addFavorite(Long userId, String crsIdx) {
+        // 이미 찜한 경우에는 예외 던짐
+        if (favoriteRepository.existsByUser_IdAndCourse_CrsIdx(userId, crsIdx)) {
+            throw FavoriteFailed.Exception;
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
+        Course course = courseRepository.findById(crsIdx)
+                .orElseThrow(() -> CourseFailed.Exception);
+
+        Favorite fav = Favorite.builder()
+                .user(user)
+                .course(course)
+                .build();
+
+        favoriteRepository.save(fav);
+    }
+}

--- a/src/main/java/com/example/runway/domain/user/entity/User.java
+++ b/src/main/java/com/example/runway/domain/user/entity/User.java
@@ -1,12 +1,8 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.entity;
 
 import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(

--- a/src/main/java/com/example/runway/domain/user/entity/User.java
+++ b/src/main/java/com/example/runway/domain/user/entity/User.java
@@ -1,8 +1,11 @@
 package com.example.runway.domain.user.entity;
 
+import com.example.runway.domain.course.entity.Course;
 import com.example.runway.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(
@@ -40,6 +43,18 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private UserStatus status = UserStatus.ACTIVE;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_viewed_course_idx")
+    private Course lastViewedCourse;
+
+    @Column(name = "last_viewed_at")
+    private LocalDateTime lastViewedAt;
+
+    public void updateLastViewedCourse(Course course) {
+        this.lastViewedCourse = course;
+        this.lastViewedAt = LocalDateTime.now();
+    }
 
 
 

--- a/src/main/java/com/example/runway/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/example/runway/domain/user/entity/UserStatus.java
@@ -1,4 +1,4 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.entity;
 
 public enum UserStatus {
     ACTIVE, SUSPENDED, DELETED

--- a/src/main/java/com/example/runway/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/runway/domain/user/exception/UserErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.runway.domain.course.error;
+package com.example.runway.domain.user.exception;
 
 import com.example.runway.global.dto.ErrorReason;
 import com.example.runway.global.error.BaseErrorCode;
@@ -6,16 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 
 @Getter
 @AllArgsConstructor
-public enum CourseErrorCode implements BaseErrorCode {
-
-    CourseNotFound(NOT_FOUND, "Course_404_1", "코스를 찾지 못하였습니다.");
-
+public enum UserErrorCode implements BaseErrorCode {
+    UserNotFound(NOT_FOUND, "User_404_1", "사용자를 찾지 못하였습니다.");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/com/example/runway/domain/user/exception/UserFailed.java
+++ b/src/main/java/com/example/runway/domain/user/exception/UserFailed.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.user.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class UserFailed extends BaseErrorException {
+    public static final UserFailed Exception = new UserFailed();
+
+    public UserFailed() {
+        super(UserErrorCode.UserNotFound);
+    }
+}

--- a/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
-package com.example.runway.domain.user;
+package com.example.runway.domain.user.repository;
 
+import com.example.runway.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/example/runway/domain/weather/config/WeatherConfig.java
+++ b/src/main/java/com/example/runway/domain/weather/config/WeatherConfig.java
@@ -1,0 +1,35 @@
+package com.example.runway.domain.weather.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WeatherConfig {
+
+    @Value("${kma.api.serviceKey}")
+    private String serviceKey;
+
+    @Value("${kma.api.baseUrl}")
+    private String baseUrl;
+
+    @Value("${airkorea.api.stationUrl}")
+    private String airKoreaStationUrl;
+    @Value("${airkorea.api.dataUrl}")
+    private String airKoreaDataUrl;
+
+    public record AirKoreaApiProperties(String stationUrl, String dataUrl, String serviceKey) {}
+
+    @Bean
+    public AirKoreaApiProperties airKoreaApiProperties() {
+        return new AirKoreaApiProperties(airKoreaStationUrl, airKoreaDataUrl,serviceKey);
+    }
+
+    public record WeatherApiProperties(String serviceKey, String baseUrl) {}
+
+    @Bean
+    public WeatherApiProperties weatherApiProperties() {
+        return new WeatherApiProperties(serviceKey, baseUrl);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/controller/WeatherController.java
+++ b/src/main/java/com/example/runway/domain/weather/controller/WeatherController.java
@@ -1,0 +1,30 @@
+package com.example.runway.domain.weather.controller;
+
+
+import com.example.runway.domain.weather.dto.WeatherResponseDto;
+import com.example.runway.domain.weather.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/public/weather")
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping
+    public ResponseEntity<WeatherResponseDto> getWeather(
+            @RequestParam("lat") double lat, // 위도
+            @RequestParam("lon") double lon) { // 경도
+
+        WeatherResponseDto weatherDto = weatherService.getWeather(lat, lon);
+        return ResponseEntity.ok(weatherDto);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/dto/WeatherResponseDto.java
+++ b/src/main/java/com/example/runway/domain/weather/dto/WeatherResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.runway.domain.weather.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WeatherResponseDto {
+    private double temperature;     // 기온
+    private String condition;       // 날씨 상태 (예: "맑음")
+    private String airQuality;      // 대기질 (예: "보통")
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/AirKoreaApiFailedException.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/AirKoreaApiFailedException.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class AirKoreaApiFailedException extends BaseErrorException {
+    public static final BaseErrorException EXCEPTION = new AirKoreaApiFailedException();
+
+    private AirKoreaApiFailedException() {
+        super(WeatherErrorCode.AIR_KOREA_API_CALL_FAILED);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/DataNotFoundException.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/DataNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class DataNotFoundException extends BaseErrorException {
+    public static final DataNotFoundException EXCEPTION = new DataNotFoundException();
+
+    private DataNotFoundException() {
+        super(WeatherErrorCode.DATA_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/StationNotFoundException.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/StationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class StationNotFoundException extends BaseErrorException {
+    public static final StationNotFoundException EXCEPTION = new StationNotFoundException();
+
+    private StationNotFoundException() {
+        super(WeatherErrorCode.STATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/WeatherApiFailedException.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/WeatherApiFailedException.java
@@ -1,0 +1,11 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class WeatherApiFailedException extends BaseErrorException {
+    public static final BaseErrorException EXCEPTION = new WeatherApiFailedException();
+
+    private WeatherApiFailedException() {
+        super(WeatherErrorCode.WEATHER_API_CALL_FAILED);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/WeatherErrorCode.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/WeatherErrorCode.java
@@ -1,0 +1,30 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.dto.ErrorReason;
+import com.example.runway.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum WeatherErrorCode implements BaseErrorCode {
+    // API 연동 실패
+    WEATHER_API_CALL_FAILED(INTERNAL_SERVER_ERROR, "WEATHER_500_1", "외부 날씨 API 호출에 실패했습니다."),
+    AIR_KOREA_API_CALL_FAILED(INTERNAL_SERVER_ERROR, "WEATHER_500_2", "외부 대기질 API 호출에 실패했습니다."),
+    // 데이터 조회 실패
+    STATION_NOT_FOUND(NOT_FOUND, "WEATHER_404_1", "근처 측정소를 찾을 수 없습니다."),
+    DATA_NOT_FOUND(INTERNAL_SERVER_ERROR, "WEATHER_500_3", "필수 응답 데이터가 누락되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.of(status.value(), code, reason);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/service/AirKoreaService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/AirKoreaService.java
@@ -1,0 +1,102 @@
+package com.example.runway.domain.weather.service;
+
+import com.example.runway.domain.weather.config.WeatherConfig.AirKoreaApiProperties;
+import com.example.runway.domain.weather.config.WeatherConfig.WeatherApiProperties;
+import com.example.runway.domain.weather.exception.AirKoreaApiFailedException;
+import com.example.runway.domain.weather.exception.StationNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AirKoreaService {
+
+    private final RestTemplate restTemplate;
+    private final AirKoreaApiProperties airKoreaApiProperties;
+
+    public String fetchNearestStationName(String tmX, String tmY) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(airKoreaApiProperties.stationUrl() + "/getNearbyMsrstnList")
+                .queryParam("serviceKey", airKoreaApiProperties.serviceKey())
+                .queryParam("returnType", "json")
+                .queryParam("tmX", tmX)
+                .queryParam("tmY", tmY)
+                .queryParam("ver", "1.1")
+                .build(true).toUri();
+        try {
+            Map<String, Object> responseMap = restTemplate.getForObject(uri, Map.class);
+            List<Map<String, Object>> items = extractItems(responseMap);
+            if (items.isEmpty()) {
+                throw StationNotFoundException.EXCEPTION;
+            }
+            return (String) items.get(0).get("stationName");
+        } catch (Exception e) {
+            log.error("Failed to fetch nearest station name.", e);
+            throw AirKoreaApiFailedException.EXCEPTION;
+        }
+    }
+
+    public Map<String, String> fetchAirQualityData(String stationName) {
+        String encodedStationName = URLEncoder.encode(stationName, StandardCharsets.UTF_8);
+        URI uri = UriComponentsBuilder
+                .fromUriString(airKoreaApiProperties.dataUrl() + "/getMsrstnAcctoRltmMesureDnsty")
+                .queryParam("serviceKey", airKoreaApiProperties.serviceKey())
+                .queryParam("returnType", "json")
+                .queryParam("numOfRows", "1")
+                .queryParam("pageNo", "1")
+                .queryParam("stationName", encodedStationName)
+                .queryParam("dataTerm", "DAILY")
+                .queryParam("ver", "1.3")
+                .build(true).toUri();
+        try {
+            Map<String, Object> responseMap = restTemplate.getForObject(uri, Map.class);
+            return parseAirKoreaData(responseMap);
+        } catch (Exception e) {
+            log.error("Failed to fetch air quality data for station: {}", stationName, e);
+            throw AirKoreaApiFailedException.EXCEPTION;
+        }
+    }
+
+    private Map<String, String> parseAirKoreaData(Map<String, Object> responseMap) {
+        List<Map<String, Object>> itemList = extractItems(responseMap);
+        if (itemList.isEmpty()) return Collections.emptyMap();
+        return itemList.get(0).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
+    }
+
+    private List<Map<String, Object>> extractItems(Map<String, Object> responseMap) {
+        if (responseMap == null || !responseMap.containsKey("response")) {
+            log.warn("API response is empty or invalid.");
+            return Collections.emptyList();
+        }
+        Map<String, Object> response = (Map<String, Object>) responseMap.get("response");
+        if (response == null || !response.containsKey("body")) {
+            Map<String, Object> header = (Map<String, Object>) response.get("header");
+            log.warn("API call failed with header: {}", header);
+            return Collections.emptyList();
+        }
+        Map<String, Object> body = (Map<String, Object>) response.get("body");
+        if (body == null || !body.containsKey("items")) {
+            log.warn("API response body contains no items field.");
+            return Collections.emptyList();
+        }
+        Object itemsObject = body.get("items");
+        if (itemsObject instanceof List) { // 에어코리아 응답은 item이 바로 List
+            return (List<Map<String, Object>>) itemsObject;
+        }
+        log.warn("Could not parse 'items' field from AirKorea API response. Found: {}", itemsObject);
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/service/CoordinateConversionService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/CoordinateConversionService.java
@@ -1,0 +1,61 @@
+package com.example.runway.domain.weather.service;
+
+import org.locationtech.proj4j.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CoordinateConversionService {
+
+    public record XYCoordinate(String x, String y) {}
+    public record TMCoordinate(String x, String y) {}
+
+    /**
+     * 위도/경도를 기상청 격자 x,y 좌표로 변환합니다.
+     */
+    public XYCoordinate convertLatLonToXY(double lat, double lon) {
+        double RE = 6371.00877; // 지구 반경(km)
+        double GRID = 5.0; // 격자 간격(km)
+        double SLAT1 = 30.0; // 투영 위도1(degree)
+        double SLAT2 = 60.0; // 투영 위도2(degree)
+        double OLON = 126.0; // 기준점 경도(degree)
+        double OLAT = 38.0; // 기준점 위도(degree)
+        double XO = 43; // 기준점 X좌표(GRID)
+        double YO = 136; // 기준점 Y좌표(GRID)
+        double DEGRAD = Math.PI / 180.0;
+        double re = RE / GRID;
+        double slat1 = SLAT1 * DEGRAD;
+        double slat2 = SLAT2 * DEGRAD;
+        double olon = OLON * DEGRAD;
+        double olat = OLAT * DEGRAD;
+        double sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+        sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+        double sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+        sf = Math.pow(sf, sn) * Math.cos(slat1) / sn;
+        double ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+        ro = re * sf / Math.pow(ro, sn);
+        double ra = Math.tan(Math.PI * 0.25 + (lat) * DEGRAD * 0.5);
+        ra = re * sf / Math.pow(ra, sn);
+        double theta = lon * DEGRAD - olon;
+        if (theta > Math.PI) theta -= 2.0 * Math.PI;
+        if (theta < -Math.PI) theta += 2.0 * Math.PI;
+        theta *= sn;
+        int x = (int) (Math.floor(ra * Math.sin(theta) + XO + 0.5));
+        int y = (int) (Math.floor(ro - ra * Math.cos(theta) + YO + 0.5));
+        return new XYCoordinate(String.valueOf(x), String.valueOf(y));
+    }
+
+    /**
+     * 위도, 경도를 TM 좌표로 변환합니다. (proj4j 라이브러리 사용)
+     */
+    public TMCoordinate convertLatLonToTM(double lat, double lon) {
+        CRSFactory crsFactory = new CRSFactory();
+        CoordinateReferenceSystem wgs84 = crsFactory.createFromName("EPSG:4326");
+        String tmParams = "+proj=tmerc +lat_0=38 +lon_0=127 +k=1 +x_0=200000 +y_0=500000 +ellps=bessel +units=m +no_defs";
+        CoordinateReferenceSystem tm = crsFactory.createFromParameters("TM_CENTRAL", tmParams);
+        CoordinateTransformFactory ctFactory = new CoordinateTransformFactory();
+        CoordinateTransform wgsToTm = ctFactory.createTransform(wgs84, tm);
+        ProjCoordinate result = new ProjCoordinate();
+        wgsToTm.transform(new ProjCoordinate(lon, lat), result);
+        return new TMCoordinate(String.valueOf(result.x), String.valueOf(result.y));
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/service/KmaWeatherService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/KmaWeatherService.java
@@ -1,0 +1,116 @@
+package com.example.runway.domain.weather.service;
+
+import com.example.runway.domain.weather.config.WeatherConfig.WeatherApiProperties;
+import com.example.runway.domain.weather.exception.WeatherApiFailedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KmaWeatherService {
+
+    private final RestTemplate restTemplate;
+    private final WeatherApiProperties weatherApiProperties;
+
+    private record BaseDateTime(String baseDate, String baseTime) {}
+
+    public Map<String, String> fetchWeatherData(String endpoint, String nx, String ny) {
+        BaseDateTime baseDateTime = getBaseDateTime(endpoint);
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(weatherApiProperties.baseUrl() + "/" + endpoint)
+                .queryParam("serviceKey", weatherApiProperties.serviceKey())
+                .queryParam("numOfRows", "60")
+                .queryParam("pageNo", "1")
+                .queryParam("dataType", "JSON")
+                .queryParam("base_date", baseDateTime.baseDate)
+                .queryParam("base_time", baseDateTime.baseTime)
+                .queryParam("nx", nx)
+                .queryParam("ny", ny)
+                .build(true)
+                .toUri();
+
+        try {
+            Map<String, Object> responseMap = restTemplate.getForObject(uri, Map.class);
+            return parseWeatherData(responseMap);
+        } catch (Exception e) {
+            log.error("Failed to fetch weather data from {}. The original error was:", endpoint, e);
+            throw WeatherApiFailedException.EXCEPTION;
+        }
+    }
+
+    private Map<String, String> parseWeatherData(Map<String, Object> responseMap) {
+        List<Map<String, Object>> itemList = extractItems(responseMap);
+        if (itemList.isEmpty()) return Collections.emptyMap();
+
+        return itemList.stream()
+                .collect(Collectors.toMap(
+                        item -> (String) item.get("category"),
+                        item -> Objects.toString(item.get("obsrValue"), (String) item.get("fcstValue")),
+                        (existingValue, newValue) -> existingValue
+                ));
+    }
+
+    private List<Map<String, Object>> extractItems(Map<String, Object> responseMap) {
+        if (responseMap == null || !responseMap.containsKey("response")) {
+            log.warn("API response is empty or invalid.");
+            return Collections.emptyList();
+        }
+        Map<String, Object> response = (Map<String, Object>) responseMap.get("response");
+        if (response == null || !response.containsKey("body")) {
+            Map<String, Object> header = (Map<String, Object>) response.get("header");
+            log.warn("API call failed with header: {}", header);
+            return Collections.emptyList();
+        }
+        Map<String, Object> body = (Map<String, Object>) response.get("body");
+        if (body == null || !body.containsKey("items")) {
+            log.warn("API response body contains no items field.");
+            return Collections.emptyList();
+        }
+        Object itemsObject = body.get("items");
+        if (!(itemsObject instanceof Map)) {
+            log.warn("API response 'items' field is not a Map: {}", itemsObject);
+            return Collections.emptyList();
+        }
+        Map<String, Object> items = (Map<String, Object>) itemsObject;
+        if (items.get("item") == null) {
+            log.warn("API response body contains no item data.");
+            return Collections.emptyList();
+        }
+        Object itemObject = items.get("item");
+        if (itemObject instanceof List) {
+            return (List<Map<String, Object>>) itemObject;
+        } else if (itemObject instanceof Map) {
+            return Collections.singletonList((Map<String, Object>) itemObject);
+        }
+        return Collections.emptyList();
+    }
+
+    private BaseDateTime getBaseDateTime(String endpoint) {
+        LocalDate date = LocalDate.now();
+        LocalTime time = LocalTime.now();
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        if ("getUltraSrtNcst".equals(endpoint)) {
+            LocalTime baseTime = time.getMinute() < 10 ? time.minusHours(1) : time;
+            return new BaseDateTime(date.format(dateFormatter), baseTime.format(DateTimeFormatter.ofPattern("HH00")));
+        } else { // "getUltraSrtFcst"
+            LocalTime baseTime = time.getMinute() < 45 ? time.minusHours(1) : time;
+            return new BaseDateTime(date.format(dateFormatter), baseTime.format(DateTimeFormatter.ofPattern("HH30")));
+        }
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/service/WeatherService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/WeatherService.java
@@ -1,0 +1,76 @@
+package com.example.runway.domain.weather.service;
+
+import com.example.runway.domain.weather.dto.WeatherResponseDto;
+import com.example.runway.domain.weather.exception.DataNotFoundException;
+import com.example.runway.domain.weather.service.CoordinateConversionService.TMCoordinate;
+import com.example.runway.domain.weather.service.CoordinateConversionService.XYCoordinate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+
+    private final CoordinateConversionService coordinateConversionService;
+    private final KmaWeatherService kmaWeatherService;
+    private final AirKoreaService airKoreaService;
+
+    /**
+     * 각 전문 서비스를 조율하여 날씨와 미세먼지 정보를 최종 조합합니다.
+     */
+    public WeatherResponseDto getWeather(double lat, double lon) {
+        // 1. 좌표 변환 서비스 호출
+        XYCoordinate xy = coordinateConversionService.convertLatLonToXY(lat, lon);
+        TMCoordinate tm = coordinateConversionService.convertLatLonToTM(lat, lon);
+
+        // 2. 기상청 날씨 서비스 호출
+        Map<String, String> liveData = kmaWeatherService.fetchWeatherData("getUltraSrtNcst", xy.x(), xy.y());
+        Map<String, String> forecastData = kmaWeatherService.fetchWeatherData("getUltraSrtFcst", xy.x(), xy.y());
+
+        // 3. 에어코리아 미세먼지 서비스 호출
+        String stationName = airKoreaService.fetchNearestStationName(tm.x(), tm.y());
+        Map<String, String> airQualityData = airKoreaService.fetchAirQualityData(stationName);
+
+
+        // 4. 모든 데이터 조합
+        String tempValue = liveData.get("T1H");
+        double temperature = (tempValue != null) ? Double.parseDouble(tempValue) : 0.0;
+
+        String skyCode = forecastData.get("SKY");
+        String condition = convertSkyCodeToCondition(skyCode);
+
+        String airQualityGrade = airQualityData.get("pm10Grade1h");
+        String airQuality = convertGradeToText(airQualityGrade);
+
+        if (tempValue == null || skyCode == null || airQualityGrade == null) {
+            throw DataNotFoundException.EXCEPTION;
+        }
+
+        return new WeatherResponseDto(temperature, condition, airQuality);
+    }
+
+    private String convertSkyCodeToCondition(String skyCode) {
+        if (skyCode == null) return "알 수 없음";
+        return switch (skyCode) {
+            case "1" -> "맑음";
+            case "3" -> "구름많음";
+            case "4" -> "흐림";
+            default -> "정보 없음";
+        };
+    }
+
+    private String convertGradeToText(String grade) {
+        if (grade == null) return "알 수 없음";
+        return switch (grade) {
+            case "1" -> "좋음";
+            case "2" -> "보통";
+            case "3" -> "나쁨";
+            case "4" -> "매우나쁨";
+            default -> "점검중";
+        };
+    }
+}

--- a/src/main/java/com/example/runway/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/runway/global/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.runway.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/runway/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/runway/global/config/SecurityConfig.java
@@ -42,8 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health")
                         .permitAll()
                         .anyRequest().authenticated())
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .formLogin(AbstractHttpConfigurer::disable);
 
         //JWT 필터 추가
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/runway/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/runway/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.runway.global.config;
 
+import com.example.runway.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,10 +10,16 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -27,7 +35,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/signup", "/", "/login", "/Oauth2/**","/auth/**")
+                        .requestMatchers("/signup", "/", "/login", "/Oauth2/**","/auth/**","public/**")
                         .permitAll()
                         .requestMatchers(SwaggerPatterns)
                         .permitAll()
@@ -36,6 +44,10 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable);
+
+        //JWT 필터 추가
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/com/example/runway/global/config/WebConfig.java
+++ b/src/main/java/com/example/runway/global/config/WebConfig.java
@@ -1,14 +1,28 @@
 package com.example.runway.global.config;
 
+import com.example.runway.global.jwt.argument_resolver.LoginUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     @Value("${server.url}")
     private String SERVER_URL;
+
+    private final LoginUserIdArgumentResolver loginUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserIdArgumentResolver);
+    }
+
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/example/runway/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.example.runway.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        // 이미 인증되어 있으면 패스
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = resolveToken(request);
+
+            if (token != null) {
+                try {
+                    if (jwtProvider.validate(token)) {
+                        String subject = jwtProvider.getSubject(token); // 로그인 시 subject = userId 로 발급했어야 함
+                        Long userId = Long.parseLong(subject);
+
+                        var principal = new JwtUserPrincipal(userId);
+                        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER")); // 필요시 롤 클레임에서 채우기
+
+                        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+                        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                    }
+                } catch (Exception e) {
+                    // 토큰이 있지만 유효하지 않으면 바로 401 리턴(원하면 주석 처리하고 체인 계속 타도 됨)
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"status\":401,\"error\":\"Unauthorized\",\"message\":\"Invalid or expired token\"}");
+                    return;
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest req) {
+        String auth = req.getHeader("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            return auth.substring(7);
+        }
+        // 쿠키 사용 시(선택)
+        if (req.getCookies() != null) {
+            for (Cookie c : req.getCookies()) {
+                if ("ACCESS_TOKEN".equals(c.getName())) {
+                    return c.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/runway/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtProvider.java
@@ -27,8 +27,8 @@ public class JwtProvider {
     public String createAccessToken(String subject, Map<String, Object> claims) {
         Instant now = Instant.now();
         return Jwts.builder()
-                .setSubject(subject)
                 .setClaims(claims)
+                .setSubject(subject)
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(now.plusSeconds(accessExpSeconds)))
                 .signWith(signingKey, SignatureAlgorithm.HS256)

--- a/src/main/java/com/example/runway/global/jwt/JwtUserPrincipal.java
+++ b/src/main/java/com/example/runway/global/jwt/JwtUserPrincipal.java
@@ -1,0 +1,3 @@
+package com.example.runway.global.jwt;
+
+public record JwtUserPrincipal(Long userId) {}

--- a/src/main/java/com/example/runway/global/jwt/annotation/LoginUserId.java
+++ b/src/main/java/com/example/runway/global/jwt/annotation/LoginUserId.java
@@ -1,0 +1,12 @@
+package com.example.runway.global.jwt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+    boolean required() default true;
+}

--- a/src/main/java/com/example/runway/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/example/runway/global/jwt/argument_resolver/LoginUserIdArgumentResolver.java
@@ -1,0 +1,49 @@
+package com.example.runway.global.jwt.argument_resolver;
+
+import com.example.runway.global.jwt.JwtUserPrincipal;
+import com.example.runway.global.jwt.annotation.LoginUserId; // ← 오타 주의: annotation X
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class)
+                && (parameter.getParameterType() == Long.class || parameter.getParameterType() == long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mav,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        LoginUserId ann = parameter.getParameterAnnotation(LoginUserId.class);
+        boolean required = (ann == null) || ann.required();
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || auth instanceof AnonymousAuthenticationToken || !auth.isAuthenticated()) {
+            if (required) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+            return null;
+        }
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof JwtUserPrincipal p) {
+            return p.userId();
+        }
+
+        // 예상과 다른 Principal 타입이면 인증 실패 처리
+        if (required) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보를 확인할 수 없습니다.");
+        return null;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,5 +4,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  jpa:
+    hibernate:
+      ddl-auto: update   # create, create-drop, update, validate, none 중 하나
+    properties:
+      hibernate:
+        format_sql: true
+
 server:
   url: ${SERVER_LOCAL_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,18 @@ spring:
       redirect: ${KAKAO_REDIRECT_URI}
 
 
+# 기온, 날씨를 받아오기 위한 api url
+kma:
+  api:
+    serviceKey: ${KMA_SERVICE_KEY}
+    baseUrl: https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
+
+# 미세먼지 받아오기 위한 api url
+airkorea:
+  api:
+    stationUrl: http://apis.data.go.kr/B552584/MsrstnInfoInqireSvc
+    dataUrl: http://apis.data.go.kr/B552584/ArpltnInforInqireSvc
+
 
 logging:
   level:


### PR DESCRIPTION


### 📄 개요

사용자 경험 향상을 위해 최근에 본 코스를 다시 확인할 수 있는 기능과, 다른 사용자들에게 인기 있는 코스를 추천하는 기능을 추가합니다.

  - **최근 본 코스**: 사용자가 마지막으로 조회한 코스 1개를 기록하고 조회하는 API를 구현했습니다.
  - **인기 코스**: 전체 사용자의 찜(Favorite) 데이터를 기반으로 가장 인기 있는 코스 10개를 조회하는 API를 구현했습니다.
  - 원활한 개발 및 테스트를 위해 `courses`, `user`, `user_course_favorite` 테이블에 대한 초기 데이터(`data.sql`)를 추가했습니다.

-----

###  ✅ 변경 사항

  - [x] 기능 추가
      - 인기 코스 조회 API (`GET public/courses/popular`)
  - [ ] 버그 수정
  - [ ] 리팩터링
  - [ ] 문서 수정
  - [ ] 테스트 코드 작성/수정
  - [ ] 기타 (아래에 상세 설명)

-----

### \#\# 🧪 테스트 방법


**인기 코스 조회 (인증 불필요)**

-----

### \#\# 📸 스크린샷 (UI 변경 시 필수)

**1. 인기 코스 조회 API (`GET /courses/popular`) 응답**

<img width="1021" height="654" alt="image" src="https://github.com/user-attachments/assets/9b41e74f-500d-4593-be18-7e17915dae56" />


-----

### \#\# 🔗 관련 이슈

  - `Open`  #9   (인기 코스 조회 기능)


-----

### \#\# ⚠️ 참고 사항

  - 인기 코스의 기준은 **총 찜(Favorite) 수**로 정의했습니다.