### PR TITLE
[Feature] : 테스트 로그인 구현

### DIFF
--- a/src/main/java/com/example/runway/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/runway/domain/auth/controller/AuthController.java
@@ -1,15 +1,14 @@
 package com.example.runway.domain.auth.controller;
 
 import com.example.runway.domain.auth.dto.LoginResponse;
+import com.example.runway.domain.auth.dto.TestLoginRequest;
+import com.example.runway.domain.auth.dto.TestLoginResponse;
 import com.example.runway.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -31,5 +30,12 @@ public class AuthController {
 
         return ResponseEntity.ok(result);
     }
+
+    @PostMapping("/auth/test")
+    public ResponseEntity<TestLoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+        TestLoginResponse response = authService.testLogin(request.email());
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/com/example/runway/domain/auth/dto/TestLoginRequest.java
+++ b/src/main/java/com/example/runway/domain/auth/dto/TestLoginRequest.java
@@ -1,0 +1,3 @@
+package com.example.runway.domain.auth.dto;
+
+public record TestLoginRequest(String email) {}

--- a/src/main/java/com/example/runway/domain/auth/dto/TestLoginResponse.java
+++ b/src/main/java/com/example/runway/domain/auth/dto/TestLoginResponse.java
@@ -1,0 +1,3 @@
+package com.example.runway.domain.auth.dto;
+
+public record TestLoginResponse(String accessToken) { }

--- a/src/main/java/com/example/runway/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/runway/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.example.runway.domain.auth.service;
 
 import com.example.runway.domain.auth.dto.LoginResponse;
+import com.example.runway.domain.auth.dto.TestLoginResponse;
 import com.example.runway.domain.user.entity.User;
 import com.example.runway.domain.user.repository.UserRepository;
 import com.example.runway.domain.user.entity.UserStatus;
@@ -11,6 +12,7 @@ import com.example.runway.infra.kakao.dto.KakaoUserInfoResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,5 +79,17 @@ public class AuthService {
                 .profileImageUrl(user.getProfileImageUrl())
                 .accessToken(accessJwt)
                 .build();
+    }
+
+    @Transactional(readOnly = true) 
+    public TestLoginResponse testLogin(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+
+        String accessToken = jwtProvider.createAccessToken(user.getId().toString(), Map.of(
+                "nickname", user.getNickname()
+        ));
+
+        return new TestLoginResponse(accessToken);
     }
 }

--- a/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/runway/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
 
+    Optional<User> findByEmail(String email);
+
 }


### PR DESCRIPTION
## 📄 개요

- 개발 및 테스트 단계의 편의성을 위해 ID(이메일)만으로 로그인하여 AccessToken을 발급받을 수 있는 테스트용 API를 추가했습니다.
- 이를 통해 카카오 등 외부 소셜 로그인 절차 없이 백엔드 기능을 빠르게 테스트할 수 있습니다. 

---

## ✅ 변경 사항
- [x] 기능 추가

- 테스트 로그인 API 엔드포인트 추가
  - POST /auth/test
  - 요청받은 username(이메일)이 DB에 존재할 경우에만 토큰을 발급합니다.


---

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1033" height="594" alt="image" src="https://github.com/user-attachments/assets/e9f0d67c-989a-4db1-a94b-315a9d8948e7" />



---

## 🔗 관련 이슈

#24 

---

## ⚠️ 참고 사항
- 리뷰어가 알아야 할 추가 설명이나 주의 사항이 있다면 작성해주세요.
