### PR TITLE
[Bugfix] 기상청 데이터가 아직 발표되지 않은 시간을 요청에 따른 에러 처리

### DIFF
--- a/src/main/java/com/example/runway/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/runway/domain/auth/service/AuthService.java
@@ -81,7 +81,7 @@ public class AuthService {
                 .build();
     }
 
-    @Transactional(readOnly = true) 
+    @Transactional(readOnly = true)
     public TestLoginResponse testLogin(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));

--- a/src/main/java/com/example/runway/domain/weather/exception/ApiCallFailedException.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/ApiCallFailedException.java
@@ -1,0 +1,12 @@
+package com.example.runway.domain.weather.exception;
+
+import com.example.runway.global.error.BaseErrorException;
+
+public class ApiCallFailedException extends BaseErrorException {
+    public static final ApiCallFailedException EXCEPTION = new ApiCallFailedException();
+
+
+    private ApiCallFailedException() {
+        super(WeatherErrorCode.ApiCallFailed);
+    }
+}

--- a/src/main/java/com/example/runway/domain/weather/exception/WeatherErrorCode.java
+++ b/src/main/java/com/example/runway/domain/weather/exception/WeatherErrorCode.java
@@ -17,7 +17,8 @@ public enum WeatherErrorCode implements BaseErrorCode {
     AIR_KOREA_API_CALL_FAILED(INTERNAL_SERVER_ERROR, "WEATHER_500_2", "외부 대기질 API 호출에 실패했습니다."),
     // 데이터 조회 실패
     STATION_NOT_FOUND(NOT_FOUND, "WEATHER_404_1", "근처 측정소를 찾을 수 없습니다."),
-    DATA_NOT_FOUND(INTERNAL_SERVER_ERROR, "WEATHER_500_3", "필수 응답 데이터가 누락되었습니다.");
+    DATA_NOT_FOUND(INTERNAL_SERVER_ERROR, "WEATHER_500_3", "필수 응답 데이터가 누락되었습니다."),
+    ApiCallFailed(INTERNAL_SERVER_ERROR,"WEATHER_500_4","기상 API 호출하는데 문제가 생겼습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/runway/domain/weather/service/KmaLivingWeatherService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/KmaLivingWeatherService.java
@@ -1,15 +1,20 @@
 package com.example.runway.domain.weather.service;
 
 import com.example.runway.domain.weather.config.WeatherConfig.KmaLivingWeatherApiProperties;
+import com.example.runway.domain.weather.exception.ApiCallFailedException;
 import com.example.runway.domain.weather.exception.DataNotFoundException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -21,39 +26,121 @@ import java.util.Optional;
 public class KmaLivingWeatherService {
     private final RestTemplate restTemplate;
     private final KmaLivingWeatherApiProperties apiProperties;
+    private final ObjectMapper objectMapper;
 
     public String fetchUvIndex(String areaCode) {
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")) + "06";
+        String latestApiTime = getLatestApiTime();
+
         URI uri = UriComponentsBuilder
-                .fromUriString(apiProperties.baseUrl() + "/getUVIdx")
+                .fromUriString(apiProperties.baseUrl() + "/getUVIdxV4")
                 .queryParam("serviceKey", apiProperties.serviceKey())
                 .queryParam("pageNo", "1")
                 .queryParam("numOfRows", "10")
                 .queryParam("dataType", "JSON")
                 .queryParam("areaNo", areaCode)
-                .queryParam("time", today)
-                .build(true).toUri();
+                .queryParam("time", latestApiTime)
+                .build(true)
+                .toUri();
+
         try {
-            Map<String, Object> responseMap = restTemplate.getForObject(uri, Map.class);
-            return parseUvIndex(responseMap).orElseThrow(() -> DataNotFoundException.EXCEPTION);
+            // API 응답을 DTO 구조로 직접 변환
+            UvApiResponse response = restTemplate.getForObject(uri, UvApiResponse.class);
+            log.info("API Response for UV index (areaCode: {}): {}", areaCode, objectMapper.writeValueAsString(response));
+
+            // DTO에서 현재 시간에 맞는 자외선 지수 값을 추출
+            return extractCurrentUvIndex(response)
+                    .orElseThrow(() -> {
+                        log.error("Failed to parse or find a valid UV index in the API response. areaCode: {}", areaCode);
+                        return DataNotFoundException.EXCEPTION;
+                    });
+
+        } catch (RestClientException e) {
+            log.error("Failed to fetch UV index from API for area code: {}. URI: {}", areaCode, uri, e);
+            throw ApiCallFailedException.EXCEPTION;
         } catch (Exception e) {
-            log.error("Failed to fetch UV index for area code: {}", areaCode, e);
+            log.error("An unexpected error occurred while processing UV index for area code: {}", areaCode, e);
             throw DataNotFoundException.EXCEPTION;
         }
     }
 
-    private Optional<String> parseUvIndex(Map<String, Object> responseMap) {
-        try {
-            Map<String, Object> response = (Map<String, Object>) responseMap.get("response");
-            Map<String, Object> body = (Map<String, Object>) response.get("body");
-            Map<String, Object> items = (Map<String, Object>) body.get("items");
-            List<Map<String, Object>> itemList = (List<Map<String, Object>>) items.get("item");
-            if (!itemList.isEmpty()) {
-                return Optional.ofNullable((String) itemList.get(0).get("today"));
-            }
-        } catch (Exception e) {
-            log.warn("Could not parse UV index from API response.", e);
+    /**
+     * 파싱된 API 응답 객체에서 현재 시간에 가장 가까운 자외선 지수 값을 추출합니다.
+     */
+    private Optional<String> extractCurrentUvIndex(UvApiResponse response) {
+        if (response == null || response.getResponse() == null || response.getResponse().getBody() == null ||
+                response.getResponse().getBody().getItems() == null || response.getResponse().getBody().getItems().getItem() == null ||
+                response.getResponse().getBody().getItems().getItem().isEmpty()) {
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        // 결과 목록의 첫 번째 항목을 가져옵니다.
+        UvApiResponse.Item item = response.getResponse().getBody().getItems().getItem().get(0);
+
+        // 현재 시간에 가장 가까운 시간 키(h0, h3, h6 등)를 찾습니다.
+        int currentHour = LocalDateTime.now().getHour();
+        int closestHour = (currentHour / 3) * 3;
+        String hourKey = "h" + closestHour;
+
+        // ObjectMapper를 사용해 객체를 Map으로 변환하여 키로 값을 쉽게 찾습니다.
+        Map<String, String> valueMap = objectMapper.convertValue(item, Map.class);
+        String uvIndex = valueMap.get(hourKey);
+
+        // 값이 null이 아니고 비어있지 않은 경우에만 Optional로 감싸 반환합니다.
+        return Optional.ofNullable(uvIndex).filter(s -> !s.isEmpty());
+    }
+
+    private String getLatestApiTime() {
+        // 데이터 발행 지연을 고려하여 현재 시간에서 3시간을 뺍니다.
+        LocalDateTime safeRequestTime = LocalDateTime.now().minusHours(3);
+
+        // API 발표 시간에 맞게 가장 가까운 이전 3의 배수 시간으로 맞춥니다.
+        int targetHour = (safeRequestTime.getHour() / 3) * 3;
+
+        // API가 요구하는 형식(yyyyMMddHH)으로 포맷팅합니다.
+        String dateString = safeRequestTime.toLocalDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String timeString = String.format("%02d", targetHour);
+
+        return dateString + timeString;
+    }
+
+    // API의 중첩된 JSON 구조를 매핑하기 위한 static DTO 클래스들
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class UvApiResponse {
+        private Response response;
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Response {
+            private Header header;
+            private Body body;
+        }
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Header {
+            private String resultCode;
+            private String resultMsg;
+        }
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Body {
+            private Items items;
+        }
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Items {
+            private List<Item> item;
+        }
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Item {
+            private String h0, h3, h6, h9, h12, h15, h18, h21, h24, h27, h30, h33, h36,
+                    h39, h42, h45, h48, h51, h54, h57, h60, h63, h66, h69, h72, h75;
+        }
     }
 }
+

--- a/src/main/java/com/example/runway/domain/weather/service/WeatherService.java
+++ b/src/main/java/com/example/runway/domain/weather/service/WeatherService.java
@@ -44,6 +44,9 @@ public class WeatherService {
         Map<String, String> liveData = kmaWeatherService.fetchWeatherData("getUltraSrtNcst", xy.x(), xy.y());
         Map<String, String> forecastData = kmaWeatherService.fetchWeatherData("getUltraSrtFcst", xy.x(), xy.y());
 
+        log.info("liveData = {}", liveData);
+        log.info("forecastData = {}", forecastData);
+
         // 3. 에어코리아 미세먼지 서비스 호출
         String stationName = airKoreaService.fetchNearestStationName(tm.x(), tm.y());
         Map<String, String> airQualityData = airKoreaService.fetchAirQualityData(stationName);
@@ -101,6 +104,8 @@ public class WeatherService {
         Map<String, String> airQualityData = airKoreaService.fetchAirQualityData(stationName);
         String uvIndexValue = kmaLivingWeatherService.fetchUvIndex(areaCode);
 
+        log.info("forecastData : {}", forecastData.toString());
+
         // 3. 데이터 조합 및 변환
         String tempValue = liveData.get("T1H");
         String windSpeedValue = liveData.get("WSD");
@@ -109,6 +114,12 @@ public class WeatherService {
         String fineDustGrade = airQualityData.get("pm10Grade1h");
 
         if (tempValue == null || windSpeedValue == null || skyCode == null || ptyCode == null || fineDustGrade == null) {
+            log.info("tempValue :{}", tempValue);
+            log.info("windSpeedValue :{}", windSpeedValue);
+            log.info("skyCode :{}", skyCode);
+            log.info("ptyCode :{}", ptyCode);
+            log.info("fineDustGrade :{}", fineDustGrade);
+
             throw DataNotFoundException.EXCEPTION;
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
   profiles:
-    active: prod
+    active: local
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 📄 개요


- 초단기실황 (getUltraSrtNcst) 시간 계산 로직 수정
  - 매시 40분에 데이터가 발표되는 점을 고려하여, 40분 이전 요청 시 안전하게 1시간 전 데이터를 조회하도록 변경했습니다.

- 초단기예보 (getUltraSrtFcst) 시간 계산 로직 수정
  - 매시 45분에 데이터가 발표되는 점을 고려하여, 45분 이전 요청 시 안전하게 1시간 전 예보 데이터를 조회하도록 변경했습니다.

- 단기예보 (getVilageFcst) 시간 계산 로직 수정
  - 3시간 단위(02시, 05시, ...)로 발표되는 기준에 맞춰, 현재 시간으로부터 조회 가능한 가장 최신 예보 발표 시간을 정확히 계산하도록 로직을 개선했습니다.

---

## ✅ 변경 사항

- [x] 버그 수정



---

## 📸 스크린샷 (UI 변경 시 필수)

---

## 🔗 관련 이슈
- 예: `Closes #12`, `Fixes #34`

---

## ⚠️ 참고 사항
- 리뷰어가 알아야 할 추가 설명이나 주의 사항이 있다면 작성해주세요.
